### PR TITLE
Return if error, rather than explicit unwrap

### DIFF
--- a/src/vcd.rs
+++ b/src/vcd.rs
@@ -284,7 +284,7 @@ fn read_hierarchy(
             Ok(())
         }
         HeaderCmd::Timescale(factor, unit) => {
-            let factor_int = u32::from_str_radix(std::str::from_utf8(factor).unwrap(), 10).unwrap();
+            let factor_int = u32::from_str_radix(std::str::from_utf8(factor).unwrap(), 10)?;
             let value = Timescale::new(factor_int, convert_timescale_unit(unit));
             h.set_timescale(value);
             Ok(())
@@ -297,7 +297,7 @@ fn read_hierarchy(
         }
     };
 
-    read_vcd_header(input, foo).unwrap();
+    read_vcd_header(input, foo)?;
     let end = input.stream_position().unwrap();
     let hierarchy = h.finish();
     let lookup = if use_id_map { Some(id_map) } else { None };


### PR DESCRIPTION
Related to https://gitlab.com/surfer-project/surfer/-/issues/228

I found another place, although for a unlikely error(?).

As my method was basically looking for methods that return `Result` and has explicit `unwrap` (that may be triggered with None) in them, I also spotted https://github.com/ekiwi/wellen/blob/befbd10cd69c8ba021e493fa8e21d756328e49f7/src/fst.rs#L573 However, I do not really understand how to rewrite this to replace `unwrap` with `?` when calling the attribute parsing methods.

Also, if https://github.com/ekiwi/wellen/blob/befbd10cd69c8ba021e493fa8e21d756328e49f7/src/fst.rs#L82 returned a `Result` instead, I think one would like to get rid of the `unwrap` here: https://github.com/ekiwi/wellen/blob/befbd10cd69c8ba021e493fa8e21d756328e49f7/src/fst.rs#L125
