### PR TITLE
hierarchy: Increase `ScopeRef` size

### DIFF
--- a/wellen/src/hierarchy.rs
+++ b/wellen/src/hierarchy.rs
@@ -75,12 +75,12 @@ impl Default for VarRef {
 /// Replaces the old `ModuleRef`.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
-pub struct ScopeRef(NonZeroU16);
+pub struct ScopeRef(NonZeroU32);
 
 impl ScopeRef {
     #[inline]
     fn from_index(index: usize) -> Option<Self> {
-        NonZeroU16::new(index as u16 + 1).map(Self)
+        NonZeroU32::new(index as u32 + 1).map(Self)
     }
 
     #[inline]


### PR DESCRIPTION
I run into some issues with https://github.com/ekiwi/wellen/blob/713b1a09aea156d7c2c083f5d187dda9d9fe506f/wellen/src/hierarchy.rs#L1030 `panic()`-ing on VCDs generated by gatelist simulations.

I don't know if that's a use case that you want to support, but I figured I should share my experience either way. Thanks for the great library!