### PR TITLE
Return error for invalid VCD command

### DIFF
--- a/wellen/inputs/github_issues/issue40.vcd
+++ b/wellen/inputs/github_issues/issue40.vcd
@@ -1,0 +1,15 @@
+$date
+        Fri Feb  7 16:00:22 2025
+$end
+$crash
+$version
+        Icarus Verilog
+$end
+$timescale
+        1ps
+$end
+$scope module proj::pipeline_ready_valid::ready_valid_pipeline $end
+$var wire 1 ! \#s1_enable $end
+$upscope $end
+$enddefinitions $end
+$dumpall

--- a/wellen/tests/vcd.rs
+++ b/wellen/tests/vcd.rs
@@ -148,3 +148,13 @@ fn amaranth_array_support_issue_36() {
     assert!(o_md_0_0.index().is_none());
     assert_eq!(o_md_0_0.length(), Some(32));
 }
+
+/// https://github.com/ekiwi/wellen/issues/40
+/// Invalid commands in the VCD file should lead to an error being returned, not a panic.
+#[test]
+fn load_github_issue_40() {
+    let filename = "inputs/github_issues/issue40.vcd";
+    let r = read(filename);
+    assert!(r.is_err());
+    assert!(r.err().unwrap().to_string().contains("unknown or invalid command"));
+}


### PR DESCRIPTION
Fix #40 by returning an error instead of explicit panic