### PR TITLE
Support float time stamps in VCD

### DIFF
--- a/wellen/inputs/migen/fractional_time_stamp.vcd
+++ b/wellen/inputs/migen/fractional_time_stamp.vcd
@@ -1,0 +1,28 @@
+$var wire 1 ! orgate0 $end
+$var wire 1 " orgate1 $end
+$var wire 1 # orgate2 $end
+$var wire 1 $ sys_clk $end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+0!
+0"
+0#
+0$
+#3.2
+1$
+#6.0
+0$
+#9.0
+1"
+1#
+1$
+#12.0
+0$
+#15.0
+1$
+0!
+0"
+0#
+0$

--- a/wellen/inputs/migen/migen.vcd
+++ b/wellen/inputs/migen/migen.vcd
@@ -1,0 +1,28 @@
+$var wire 1 ! orgate0 $end
+$var wire 1 " orgate1 $end
+$var wire 1 # orgate2 $end
+$var wire 1 $ sys_clk $end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+0!
+0"
+0#
+0$
+#3.0
+1$
+#6.0
+0$
+#9.0
+1"
+1#
+1$
+#12.0
+0$
+#15.0
+1$
+0!
+0"
+0#
+0$

--- a/wellen/inputs/migen/migen_original.vcd
+++ b/wellen/inputs/migen/migen_original.vcd
@@ -1,0 +1,27 @@
+$var wire 1 ! orgate0 $end
+$var wire 1 " orgate1 $end
+$var wire 1 # orgate2 $end
+$var wire 1 $ sys_clk $end
+$dumpvars
+$end
+#0
+0!
+0"
+0#
+0$
+#3.0
+1$
+#6.0
+0$
+#9.0
+1"
+1#
+1$
+#12.0
+0$
+#15.0
+1$
+0!
+0"
+0#
+0$

--- a/wellen/tests/vcd.rs
+++ b/wellen/tests/vcd.rs
@@ -165,3 +165,21 @@ fn load_github_issue_40() {
     assert!(r.is_err());
     assert!(r.err().unwrap().to_string().contains("unknown or invalid command"));
 }
+
+
+/// Time stamps ending with .0 can show up from Migen. Make sure they can be parsed.
+#[test]
+fn load_github_issue_55_float_time_stamp() {
+    let filename = "inputs/migen/migen.vcd";
+    let _waves = read(filename).expect("failed to parse");
+}
+
+/// Error for float time stamps that does not have a zero fractional part.
+/// Migen will not produce these, but someone may...
+#[test]
+fn load_github_issue_55_fractional_time_stamp() {
+    let filename = "inputs/migen/fractional_time_stamp.vcd";
+    let r = read(filename);
+    assert!(r.is_err());
+    assert!(r.err().unwrap().to_string().contains("parse an integer"));
+}


### PR DESCRIPTION
Closes #55

If this looks OK I can add two tests (one with zero fractional part, one with non-zero).