### PR TITLE
Micro-optimizations

### DIFF
--- a/wellen/src/fst.rs
+++ b/wellen/src/fst.rs
@@ -241,7 +241,7 @@ impl SignalWriter {
                     }
                 }
                 SignalEncoding::Real => panic!(
-                    "Expecting reals, but go: {}",
+                    "Expecting reals, but got: {}",
                     String::from_utf8_lossy(value)
                 ),
             },

--- a/wellen/src/fst.rs
+++ b/wellen/src/fst.rs
@@ -227,7 +227,6 @@ impl SignalWriter {
                     } else {
                         // smaller encoding than the maximum
                         self.data_bytes.push(meta_data);
-                        let (local_len, _) = get_len_and_meta(local_encoding, bits);
                         if has_meta {
                             push_zeros(&mut self.data_bytes, len - local_len);
                         } else {

--- a/wellen/src/fst.rs
+++ b/wellen/src/fst.rs
@@ -293,7 +293,7 @@ impl SignalWriter {
 
 #[inline]
 pub fn get_len_and_meta(states: States, bits: u32) -> (usize, bool) {
-    let len = (bits as usize).div_ceil(states.bits_in_a_byte());
+    let len = states.bytes_required(bits as usize);
     let has_meta = (states != States::Two) && ((bits as usize) % states.bits_in_a_byte() == 0);
     (len, has_meta)
 }

--- a/wellen/src/ghw/signals.rs
+++ b/wellen/src/ghw/signals.rs
@@ -242,7 +242,7 @@ impl VecBufferInfo {
     fn data_range(&self) -> std::ops::Range<usize> {
         // data is stored with N bits per byte depending on the states
         let start = self.data_start as usize;
-        let len = (self.bits as usize).div_ceil(self.states.bits_in_a_byte());
+        let len = self.states.bytes_required(self.bits as usize);
         start..(start + len)
     }
 }
@@ -269,7 +269,7 @@ impl VecBuffer {
                     signal_ref: vector.signal_ref(),
                     max_index: vector.max().index() as u32,
                 };
-                data_start += (bits as usize).div_ceil(states.bits_in_a_byte());
+                data_start += states.bytes_required(bits as usize);
                 bit_change_start += (bits as usize).div_ceil(8);
                 info
             })

--- a/wellen/src/signals.rs
+++ b/wellen/src/signals.rs
@@ -672,8 +672,7 @@ impl SignalChangeData {
                                     println!("ERROR: offset={offset}, encoding={encoding:?}, width={width}, raw_data[0]={}", raw_data[0]);
                                 }
                                 let states = States::try_from_primitive(meta_value).unwrap();
-                                let num_out_bytes =
-                                    (*bits as usize).div_ceil(states.bits_in_a_byte());
+                                let num_out_bytes = states.bytes_required(*bits as usize);
                                 debug_assert!(num_out_bytes <= data.len());
                                 let signal_bytes = if num_out_bytes == data.len() {
                                     data

--- a/wellen/src/signals.rs
+++ b/wellen/src/signals.rs
@@ -378,10 +378,9 @@ impl BitVectorBuilder {
             let meta_data = (local_encoding as u8) << 6;
             self.data.push(value | meta_data);
         } else {
-            let num_bytes = (self.bits as usize).div_ceil(local_encoding.bits_in_a_byte());
             let (data, mask) = value.data_and_mask().unwrap();
-            assert_eq!(data.len(), num_bytes);
             let (local_len, local_has_meta) = get_len_and_meta(local_encoding, self.bits);
+            assert_eq!(data.len(), local_len);
 
             // append data
             let meta_data = (local_encoding as u8) << 6;

--- a/wellen/src/wavemem.rs
+++ b/wellen/src/wavemem.rs
@@ -794,7 +794,7 @@ impl SignalEncoder {
                         try_write_1_bit_9_state(time_idx_delta, value_char, &mut self.data)
                             .unwrap_or_else(|| {
                                 panic!(
-                                    "Failed to parse four state value: {} for signal of size 1",
+                                    "Failed to parse nine-state value: {} for signal of size 1",
                                     String::from_utf8_lossy(value)
                                 )
                             });
@@ -802,7 +802,7 @@ impl SignalEncoder {
                 } else {
                     let states = check_states(value_bits).unwrap_or_else(|| {
                         panic!(
-                            "Bit-vector contains invalid character. Only 2, 4 and 9-state signals are supported: {}",
+                            "Bit-vector contains invalid character. Only 2-, 4-, and 9-state signals are supported: {}",
                             String::from_utf8_lossy(value)
                         )
                     });
@@ -819,7 +819,7 @@ impl SignalEncoder {
                         let expanded = expand_special_vector_cases(value_bits, bits)
                             .unwrap_or_else(|| {
                                 panic!(
-                                    "Failed to parse four state value: {} for signal of size {}",
+                                    "Failed to parse four-state value: {} for signal of size {}",
                                     String::from_utf8_lossy(value),
                                     bits
                                 )


### PR DESCRIPTION
Three commits:
1. Remove two redundant calls (one, as the other is only present in debug mode)
2. Introduce `bytes_required` method which gives a small performance improvement, not a lot in total, but 25% or so in `get_len_and_meta`. (Hard to say as one will have to run without --opt-level 3 to get flamegraphs, but Godbolt indicates a reduction from 7 to 3 instructions compared to `div_ceil`.) I also think it improves the readability a bit.
3. Fix some minor issues with comments (two, the rest are just unification...)

Separate commits to make it easy to revert, but feel free to squash/ask me to squash.