### PR TITLE
Add support for as and zs time units

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["wellen", "pywellen"]
 default-members = ["wellen"]
 
 [workspace.package]
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.81.0"
 authors = ["Kevin Laeufer <laeufer@berkeley.edu>"]

--- a/wellen/src/fst.rs
+++ b/wellen/src/fst.rs
@@ -84,8 +84,7 @@ impl<R: BufRead + Seek + Sync + Send> SignalSourceImplementation for FstWaveData
         // create a FST filter
         let fst_ids = ids
             .iter()
-            .zip(types.iter())
-            .map(|(ii, _)| FstSignalHandle::from_index(ii.index()))
+            .map(|ii| FstSignalHandle::from_index(ii.index()))
             .collect::<Vec<_>>();
         let filter = FstFilter::filter_signals(fst_ids);
 

--- a/wellen/src/fst.rs
+++ b/wellen/src/fst.rs
@@ -506,6 +506,16 @@ fn convert_timescale(exponent: i8) -> Timescale {
             10u32.pow((exponent + 15) as u32),
             TimescaleUnit::FemtoSeconds,
         )
+    } else if exponent >= -18 {
+        Timescale::new(
+            10u32.pow((exponent + 18) as u32),
+            TimescaleUnit::AttoSeconds,
+        )
+    } else if exponent >= -21 {
+        Timescale::new(
+            10u32.pow((exponent + 21) as u32),
+            TimescaleUnit::ZeptoSeconds,
+        )
     } else {
         panic!("Unexpected timescale exponent: {}", exponent);
     }

--- a/wellen/src/hierarchy.rs
+++ b/wellen/src/hierarchy.rs
@@ -24,6 +24,8 @@ impl Timescale {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum TimescaleUnit {
+    ZeptoSeconds,
+    AttoSeconds,
     FemtoSeconds,
     PicoSeconds,
     NanoSeconds,
@@ -36,6 +38,8 @@ pub enum TimescaleUnit {
 impl TimescaleUnit {
     pub fn to_exponent(&self) -> Option<i8> {
         match &self {
+            TimescaleUnit::ZeptoSeconds => Some(-21),
+            TimescaleUnit::AttoSeconds => Some(-18),
             TimescaleUnit::FemtoSeconds => Some(-15),
             TimescaleUnit::PicoSeconds => Some(-12),
             TimescaleUnit::NanoSeconds => Some(-9),

--- a/wellen/src/vcd.rs
+++ b/wellen/src/vcd.rs
@@ -560,6 +560,8 @@ fn find_last(haystack: &[u8], needle: u8) -> Option<usize> {
 
 fn convert_timescale_unit(name: &[u8]) -> TimescaleUnit {
     match name {
+        b"zs" => TimescaleUnit::ZeptoSeconds,
+        b"as" => TimescaleUnit::AttoSeconds,
         b"fs" => TimescaleUnit::FemtoSeconds,
         b"ps" => TimescaleUnit::PicoSeconds,
         b"ns" => TimescaleUnit::NanoSeconds,

--- a/wellen/tests/diff_ghw.rs
+++ b/wellen/tests/diff_ghw.rs
@@ -102,6 +102,8 @@ fn diff_hierarchy_item(
 
 fn as_fs(timescale: Timescale) -> u64 {
     let factor = match timescale.unit {
+        TimescaleUnit::ZeptoSeconds => unreachable!("should not get here!"),
+        TimescaleUnit::AttoSeconds => unreachable!("should not get here!"),
         TimescaleUnit::FemtoSeconds => 1,
         TimescaleUnit::PicoSeconds => 1000,
         TimescaleUnit::NanoSeconds => 1000 * 1000,


### PR DESCRIPTION
While browsing the code of libfst, I realized that it supports attoseconds and zeptoseconds as well:
https://github.com/gtkwave/libfst/blob/6a52070cd62ec65c29832bc95e7db493504aa7ac/src/fstapi.c#L2403-L2410

It also seems like they print as and zs when converting to VCD
https://github.com/gtkwave/libfst/blob/6a52070cd62ec65c29832bc95e7db493504aa7ac/src/fstapi.c#L4127-L4145

Not sure if any simulators support it though...

Edit: nice with the semver check! I guess this means bumping to 0.17...